### PR TITLE
Change CLI Flags to all use the same format

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -35,16 +35,16 @@ exec /opt/teku/bin/teku \
     --ee-endpoint=$HTTP_ENGINE \
     --ee-jwt-secret-file="/jwtsecret" \
     --p2p-port=$P2P_PORT \
+    --rest-api-enabled=true \
     --rest-api-cors-origins="*" \
     --rest-api-interface=0.0.0.0 \
     --rest-api-port=$BEACON_API_PORT \
-    --rest-api-host-allowlist "*" \
-    --rest-api-enabled=true \
+    --rest-api-host-allowlist="*" \
     --rest-api-docs-enabled=true \
     --metrics-enabled=true \
-    --metrics-interface 0.0.0.0 \
-    --metrics-port 8008 \
-    --metrics-host-allowlist "*" \
+    --metrics-interface=0.0.0.0 \
+    --metrics-port=8008 \
+    --metrics-host-allowlist="*" \
     --log-destination=CONSOLE \
     --validators-proposer-default-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
     $EXTRA_OPTS


### PR DESCRIPTION
The flags provided use different syntaxes, most are `--flag=value` while some are `--flag value`.  It shouldn't really make a difference when run, but im trying to debug an issue with making calls to the beacon API this was one thing i noticed, and am changing to all be `--flag=value` for stylistic purposes if nothing else.